### PR TITLE
Setup Tim's Documentation Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Claude Code documentation and analysis
+Services/Sprint 2/Tim/claude/


### PR DESCRIPTION

  ## What

  - Create Tim folder under Services/Sprint 2/
  (parallel to Tom/Tan)
  - Add documentation and analysis files
  - Update .gitignore to exclude documentation
  - Establish Git branching standards

  ## Why
  Organizational setup for Tim's development work in
  Sprint 2.

  ## Testing
  - [x] Folder structure created correctly
  - [x] .gitignore properly excludes documentation
  - [x] No functional code changes

  ## Notes
  Documentation and structure only - no functional
  changes.