### PR TITLE
Tim - Fix bug #3: logout user role change security vulnerability

### DIFF
--- a/Services/Sprint1/Tom/TokenService.cs
+++ b/Services/Sprint1/Tom/TokenService.cs
@@ -11,12 +11,26 @@ namespace RestfulAPI_FarmTimeManagement.Services.Sprint1.Tom
 {
     public static class TokenService
     {
+        // =================================================================
+        // Bug Fix: Logout User Role Change Security Vulnerability
+        // Developer: Tim
+        // Date: 2025-09-21
+        // Description: Add token invalidation when user role is changed
+        // Issue: Users retain admin privileges after role downgrade
+        // =================================================================
+
         // Có thể đọc các giá trị này từ IConfiguration
         private const string Issuer = "FarmTimeManagement";
         private const string Audience = "FarmTimeManagement.Clients";
         private static readonly string Key =
             Environment.GetEnvironmentVariable("FTM_JWT_KEY")
             ?? "REPLACE_WITH_LONG_RANDOM_SECRET_32+CHARS";
+
+        // =================================================================
+        // START: Token Invalidation Mechanism
+        // Purpose: Store invalidated tokens when user roles are changed
+        // =================================================================
+        private static readonly HashSet<string> _invalidatedTokens = new HashSet<string>();
 
         public static string Generate(Staff staff, TimeSpan? lifetime = null)
         {
@@ -45,6 +59,58 @@ namespace RestfulAPI_FarmTimeManagement.Services.Sprint1.Tom
 
             return new JwtSecurityTokenHandler().WriteToken(token);
         }
+
+        // =================================================================
+        // Token Invalidation Methods
+        // Purpose: Provide mechanism to invalidate tokens when role changes
+        // =================================================================
+
+        /// <summary>
+        /// Invalidate a specific token (makes it unusable)
+        /// Used when user role is changed
+        /// </summary>
+        /// <param name="token">JWT token to invalidate</param>
+        public static void InvalidateToken(string token)
+        {
+            if (!string.IsNullOrEmpty(token))
+            {
+                _invalidatedTokens.Add(token);
+            }
+        }
+
+        /// <summary>
+        /// Check if a token is still valid (not invalidated)
+        /// </summary>
+        /// <param name="token">JWT token to check</param>
+        /// <returns>True if token is valid, false if invalidated</returns>
+        public static bool IsTokenValid(string token)
+        {
+            return !_invalidatedTokens.Contains(token);
+        }
+
+        /// <summary>
+        /// Extract staff ID from JWT token for identification
+        /// </summary>
+        /// <param name="token">JWT token</param>
+        /// <returns>Staff ID if found, null otherwise</returns>
+        public static int? GetStaffIdFromToken(string token)
+        {
+            try
+            {
+                var handler = new JwtSecurityTokenHandler();
+                var jwt = handler.ReadJwtToken(token);
+                var staffIdClaim = jwt.Claims.FirstOrDefault(c => c.Type == "staff_id")?.Value;
+                return int.TryParse(staffIdClaim, out int id) ? id : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // =================================================================
+        // END: Token Invalidation Methods
+        // =================================================================
 
     }
 }


### PR DESCRIPTION
  - Add token invalidation mechanism in TokenService.cs to handle role changes
  - Implement role change detection in StaffsController.cs Update method
  - Add token validation in CurrentStaffMiddleware to prevent invalidated token usage
  - User tokens are immediately invalidated when their role is changed
  - Force user logout and re-authentication when role changes occur
  - Return appropriate response with requireRelogin flag for client handling

  Resolves: Logout User Role Change Security
  Vulnerability
  Files modified: 3 (TokenService.cs,
  StaffsController.cs, Program.cs)
  Lines added: +47, Lines modified: ~15

  Security fix ensures users cannot retain elevated
  privileges after role downgrade. @nguy1710  @tran0702 